### PR TITLE
docs: Remove outdated visualization list from README Description

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,15 +31,6 @@ The core visualization functionalities are inherited from the original work. `nl
 ## Description
 `nlplot_llm` extends the original `nlplot` library by integrating robust LLM capabilities through LiteLLM. This allows for advanced text analysis tasks like sentiment analysis, categorization, and summarization across a wide range of language models—with customizable prompts, response caching, and asynchronous operations—while retaining useful NLP visualizations.
 
-You can draw the following graph
-
-1. [N-gram bar chart](https://htmlpreview.github.io/?https://github.com/takapy0210/takapy_blog/blob/master/nlp/twitter_analytics_using_nlplot/2020-05-17_uni-gram.html)
-2. [N-gram tree Map](https://htmlpreview.github.io/?https://github.com/takapy0210/takapy_blog/blob/master/nlp/twitter_analytics_using_nlplot/2020-05-17_Tree%20of%20Most%20Common%20Words.html)
-3. [Histogram of the word count](https://htmlpreview.github.io/?https://github.com/takapy0210/takapy_blog/blob/master/nlp/twitter_analytics_using_nlplot/2020-05-17_number%20of%20words%20distribution.html)
-4. [wordcloud](https://github.com/takapy0210/takapy_blog/blob/master/nlp/twitter_analytics_using_nlplot/wordcloud.png)
-5. [co-occurrence networks](https://htmlpreview.github.io/?https://github.com/takapy0210/takapy_blog/blob/master/nlp/twitter_analytics_using_nlplot/2020-05-17_Co-occurrence%20network.html)
-6. [sunburst chart](https://htmlpreview.github.io/?https://github.com/takapy0210/takapy_blog/blob/master/nlp/twitter_analytics_using_nlplot/2020-05-17_sunburst%20chart.html)
-
 ## Requirement
 - Python 3.7+
 - Core dependencies: `pandas`, `numpy`, `plotly>=4.12.0`, `matplotlib`, `wordcloud`, `pillow`, `networkx`, `seaborn`, `tqdm`.


### PR DESCRIPTION
The list of visualization examples in the Description section of the README pointed to external blog posts related to the original nlplot library. This list was redundant as the core visualization features are already mentioned in the 'Key Features' section and nlplot_llm's primary focus is on LLM integration.

This commit removes the outdated list to make the Description more concise and focused on nlplot_llm's unique contributions.